### PR TITLE
Fix versions in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-aiohttp
-jsonrpcserver
-tensorflow<1.4.0
-jsonrpcclient
-requests
+aiohttp==3.4.4
+jsonrpcclient==2.5.2
+jsonrpcserver==3.5.6
+requests==2.20.0
+tensorflow==1.3.0


### PR DESCRIPTION
CirclecCI build fails because new jsonrpcserver version 4.0.0 is not compatible with the previous one.
The solution is to fix dependency versions in the requirements.txt file.